### PR TITLE
Build releases once

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,11 +3,8 @@ name: Go
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
-
   build_and_release:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
The "push" and "pull_requests" actions were overlapping when merging PRs to main, so actions were being ran twice.