### PR TITLE
Prevent file overwrites with errors/logs 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/oliverhohn/woodhouse
 
 go 1.15
 
-require github.com/djherbis/times v1.2.0
+require (
+	github.com/djherbis/times v1.2.0
+	github.com/fatih/color v1.10.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
 github.com/djherbis/times v1.2.0 h1:xANXjsC/iBqbO00vkWlYwPWgBgEVU6m6AFYg0Pic+Mc=
 github.com/djherbis/times v1.2.0/go.mod h1:CGMZlo255K5r4Yw0b9RRfFQpM2y7uOmxg4jm9HsaVf8=
+github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
+github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/organizemyfiles/main.go
+++ b/organizemyfiles/main.go
@@ -84,6 +84,18 @@ func (f *File) GetExt() string {
 	return filepath.Ext(f.Path)
 }
 
+func (f *File) GetOutputDir() string {
+	return filepath.Join(*outDir, f.GetYear(), f.GetQuarter())
+}
+
+func (f *File) GetOutputFilename(suffix string) string {
+	if suffix != "" {
+		return fmt.Sprintf("%s_%s%s", f.GetName(), suffix, f.GetExt())
+	}
+
+	return fmt.Sprintf("%s%s", f.GetName(), f.GetExt())
+}
+
 func main() {
 	flag.Parse()
 
@@ -148,9 +160,9 @@ func shouldIgnoreFile(f *File) bool {
 }
 
 func copy(f *File, fileIndex uint64) error {
-	outPrefix := filepath.Join(*outDir, f.GetYear(), f.GetQuarter())
+	outPrefix := f.GetOutputDir()
 	// Suffix filename with an index to avoid clashes for similarly named files
-	outFilename := fmt.Sprintf("%s_%d%s", f.GetName(), fileIndex, f.GetExt())
+	outFilename := f.GetOutputFilename(strconv.FormatUint(fileIndex, 10))
 	out := filepath.Join(outPrefix, outFilename)
 
 	if *dryrun {
@@ -186,9 +198,9 @@ func copy(f *File, fileIndex uint64) error {
 }
 
 func move(f *File, fileIndex uint64) error {
-	outPrefix := filepath.Join(*outDir, f.GetYear(), f.GetQuarter())
+	outPrefix := f.GetOutputDir()
 	// Suffix filename with an index to avoid clashes for similarly named files
-	outFilename := fmt.Sprintf("%s_%d%s", f.GetName(), fileIndex, f.GetExt())
+	outFilename := f.GetOutputFilename(strconv.FormatUint(fileIndex, 10))
 	out := filepath.Join(outPrefix, outFilename)
 
 	if *dryrun {

--- a/organizemyfiles/main.go
+++ b/organizemyfiles/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/djherbis/times"
+	"github.com/fatih/color"
 )
 
 var inDir = flag.String("in", "", "Path to directory with files to organize")
@@ -165,6 +166,15 @@ func copy(f *File, fileIndex uint64) error {
 	outFilename := f.GetOutputFilename(strconv.FormatUint(fileIndex, 10))
 	out := filepath.Join(outPrefix, outFilename)
 
+	// Prevent overwrites by raising an error if the output file already exists
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		if *dryrun {
+			logError("(dryrun) unable to copy %s to: %s, as the output file already exists\n", f.Path, out)
+			return nil
+		}
+		return fmt.Errorf("unable to copy %s to: %s, as the output file already exists", f.Path, out)
+	}
+
 	if *dryrun {
 		fmt.Printf("(dryrun) Copy %s to %s\n", f.Path, out)
 		return nil
@@ -203,6 +213,15 @@ func move(f *File, fileIndex uint64) error {
 	outFilename := f.GetOutputFilename(strconv.FormatUint(fileIndex, 10))
 	out := filepath.Join(outPrefix, outFilename)
 
+	// Prevent overwrites by raising an error if the output file already exists
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		if *dryrun {
+			logError("(dryrun) unable to move %s to: %s, as the output file already exists\n", f.Path, out)
+			return nil
+		}
+		return fmt.Errorf("unable to move %s to: %s, as the output file already exists", f.Path, out)
+	}
+
 	if *dryrun {
 		fmt.Printf("(dryrun) Move %s to %s\n", f.Path, out)
 		return nil
@@ -219,4 +238,8 @@ func move(f *File, fileIndex uint64) error {
 	fmt.Printf("Moved %s to %s\n", f.Path, out)
 
 	return nil
+}
+
+func logError(msg string, args ...interface{}) {
+	color.Red(fmt.Sprintf(msg, args...))
 }


### PR DESCRIPTION
Loss of data could previously occur if two (or more) different files, with the same name, birth time, and file index (when listing), exist in different input directories.

For example, for:
- File 1: `/some/path/to/file_a.png` (btime: `2020.01.01`),
- File 2: `/some/different/path/to/file_a.png` (btime: `2020.01.01`),
- `out`: `/some/output/directory`

File 1 and File 2 would result in the same output location: `/some/output/directory/00_jan_to_mar/file_a.png`, even though they could be different images. Thus resulting in the most recent move/copy to overwrite the previously moved/copied file.

## Other Changes
- Encapsulate output path logic in File functions.
- Support color logging.
