### PR TITLE
Prevent quarter ends being assigned to next quarter

### DIFF
--- a/organizemyfiles/main.go
+++ b/organizemyfiles/main.go
@@ -56,7 +56,13 @@ func (f *File) GetQuarter() string {
 		return Undefined
 	}
 
-	switch quarterIndex := f.CreatedAt.Month() / 3; quarterIndex {
+	// Month() starts at 1 for January, and ends at 12 for December.
+	// By subtracting by -1 we can ensure that:
+	// Jan -> March is 0
+	// April -> June is 1
+	// July -> September is 2
+	// October -> December is 3
+	switch quarterIndex := (f.CreatedAt.Month() - 1) / 3; quarterIndex {
 	case 0:
 		return "00_jan_to_mar"
 	case 1:


### PR DESCRIPTION
Previously, this would assign the end of the quarter to the start of the next quarter as the "month count" starts at 1 **and not** 0.

For example, for March, month count: 3, the previous implementation would assign it to quarter 1 ("01_apr_to_jun") as `3/3 == int(1)`. In addition, this would error for the month of December, as the quarter index 4 is not handled.